### PR TITLE
fix out-of-bounds access

### DIFF
--- a/gif/GifEncoder.hx
+++ b/gif/GifEncoder.hx
@@ -35,7 +35,7 @@ class GifEncoder {
 
     var width: Int;
     var height: Int;
-    var framerate: Int = 24;                 // used if frame.delay < 0
+    var framerate: Float = 24;                 // used if frame.delay < 0
     var repeat: Int = -1;                    // -1: infinite, 0: none, >0: repeat count
 
     var colorDepth: Int = 8;                 // Number of bit planes
@@ -82,7 +82,7 @@ class GifEncoder {
     public function new(
         _frame_width:Int,
         _frame_height:Int,
-        _framerate:Int,
+        _framerate:Float,
         _repeat:Int = GifRepeat.Infinite,
         _quality:Int = 10
     ) {

--- a/gif/NeuQuant.hx
+++ b/gif/NeuQuant.hx
@@ -317,8 +317,6 @@ class NeuQuant {
                 }
                 else
                 {
-                    i++;
-
                     if (dist < 0)
                         dist = -dist;
 
@@ -344,6 +342,8 @@ class NeuQuant {
                             best = network[i*4 + 3];
                         }
                     }
+
+                    i++;
                 }
             }
 
@@ -357,8 +357,6 @@ class NeuQuant {
                 }
                 else
                 {
-                    j--;
-
                     if (dist < 0)
                         dist = -dist;
 
@@ -384,6 +382,8 @@ class NeuQuant {
                             best = network[j*4 + 3];
                         }
                     }
+
+                    j--;
                 }
             }
         }
@@ -441,18 +441,18 @@ class NeuQuant {
 
             if (j < hi)
             {
-                j++;
                 network[j * 4 + 0] -= Std.int((a * (network[j * 4 + 0] - b)) / alpharadbias);
                 network[j * 4 + 1] -= Std.int((a * (network[j * 4 + 1] - g)) / alpharadbias);
                 network[j * 4 + 2] -= Std.int((a * (network[j * 4 + 2] - r)) / alpharadbias);
+                j++;
             }
 
             if (k > lo)
             {
-                k--;
                 network[k * 4 + 0] -= Std.int((a * (network[k * 4 + 0] - b)) / alpharadbias);
                 network[k * 4 + 1] -= Std.int((a * (network[k * 4 + 1] - g)) / alpharadbias);
                 network[k * 4 + 2] -= Std.int((a * (network[k * 4 + 2] - r)) / alpharadbias);
+                k--;
             }
         }
     }


### PR DESCRIPTION
Taking a closer look at the original c# lib it can be seen that in some places it first saves the value referenced by an index, and then modifies the latter (https://github.com/Chman/Moments/blob/ca6c2b10fc2b559f00c9ea6125f0d2cc8d718164/Moments%20Recorder/Scripts/Gif/NeuQuant.cs#L291-L300). Currently the haxe port could possibly try to access an out-of-bounds value. This PR aims to fix that.